### PR TITLE
add pip dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,8 @@ setup(
         "Topic :: Utilities",
         "License :: OSI Approved :: Apache Software License",
     ],
+    install_requires=[
+        'elasticsearch>=2.0.0,<3.0.0',
+        'scikit-learn>=0.17'
+    ],
 )


### PR DESCRIPTION
add pip dependency on elasticsearch and scikit-learn
I think that chainer is an option, so I don't add dependency on chainer.

Please confirm versions of dependent packages.