### PR TITLE
add 'label' and 'number' to custom_dict_vectorizer

### DIFF
--- a/commonml/text/custom_dict_vectorizer.py
+++ b/commonml/text/custom_dict_vectorizer.py
@@ -46,9 +46,9 @@ class NumberPaththroughVectorizer(object):
 class ExtendedLabelBinarizer(LabelBinarizer):
 
     def __init__(self, neg_label=0, pos_label=1,
-          sparse_output=False, labelindex_path=None):
+                 sparse_output=False, labelindex_path=None):
         super(ExtendedLabelBinarizer, self) \
-          .__init__(neg_label, pos_label, sparse_output)
+            .__init__(neg_label, pos_label, sparse_output)
         self.labelindex_path = labelindex_path
         if self.labelindex_path is not None:
             with open(self.labelindex_path, 'r') as f:

--- a/commonml/text/custom_dict_vectorizer.py
+++ b/commonml/text/custom_dict_vectorizer.py
@@ -5,14 +5,58 @@ from logging import getLogger
 from commonml import es
 from commonml.utils import get_nested_value
 from scipy.sparse.construct import hstack
+from scipy.sparse import csr_matrix
 from sklearn.base import BaseEstimator
 from sklearn.feature_extraction.text import VectorizerMixin, TfidfVectorizer, \
     CountVectorizer
+from sklearn.preprocessing import LabelBinarizer
 
 import numpy as np
+import json
 
 
 logger = getLogger('commonml.text.custom_dict_vectorizer')
+
+class NumberPaththroughVectorizer(object):
+
+    def __init__(self, dtype):
+        self.dtype_text = dtype
+        self.vocabulary_ = ['number']
+
+    def fit(self, raw_documents):
+        pass
+
+    def transform(self, raw_documents):
+        if self.dtype_text == 'float32':
+            dtype = np.float32
+        elif self.dtype_text == 'int32':
+            dtype = np.int32
+        output = [[number] for number in raw_documents]
+        return csr_matrix(output, dtype=dtype)
+
+    def fit_transform(self, raw_documents):
+        return self.transform(self, raw_documents)
+
+    def get_feature_names(self):
+        # TODO what do i return
+        return self.vocabulary_
+
+class ExtendedLabelBinarizer(LabelBinarizer):
+
+    def __init__(self, neg_label=0, pos_label=1, sparse_output=False, labelindex_path=None):
+        super(ExtendedLabelBinarizer, self).__init__(neg_label, pos_label, sparse_output)
+        self.labelindex_path = labelindex_path
+        if self.labelindex_path is not None:
+            with open(self.labelindex_path, 'r') as f:
+                self.labelindex = json.load(f)
+    def fit(self, y):
+        if self.labelindex_path is not None:
+            super(ExtendedLabelBinarizer, self).fit(self.labelindex)
+        else:
+            super(ExtendedLabelBinarizer, self).fit(y)
+
+    def get_feature_names(self):
+        return self.classes_
 
 
 def build_custom_vectorizer(config):
@@ -30,6 +74,10 @@ def build_custom_vectorizer(config):
             vectorizer = CountVectorizer(**vect_args)
         elif vect_type == 'tfidf':
             vectorizer = TfidfVectorizer(**vect_args)
+        elif vect_type == 'number':
+            vectorizer = NumberPaththroughVectorizer(**vect_args)
+        elif vect_type == 'label':
+            vectorizer = ExtendedLabelBinarizer(**vect_args)
         if vectorizer is not None:
             vect_rule['vectorizer'] = vectorizer
             vect_rules.append(vect_rule)

--- a/commonml/text/custom_dict_vectorizer.py
+++ b/commonml/text/custom_dict_vectorizer.py
@@ -17,6 +17,7 @@ import json
 
 logger = getLogger('commonml.text.custom_dict_vectorizer')
 
+
 class NumberPaththroughVectorizer(object):
 
     def __init__(self, dtype):
@@ -41,14 +42,18 @@ class NumberPaththroughVectorizer(object):
         # TODO what do i return
         return self.vocabulary_
 
+
 class ExtendedLabelBinarizer(LabelBinarizer):
 
-    def __init__(self, neg_label=0, pos_label=1, sparse_output=False, labelindex_path=None):
-        super(ExtendedLabelBinarizer, self).__init__(neg_label, pos_label, sparse_output)
+    def __init__(self, neg_label=0, pos_label=1,
+          sparse_output=False, labelindex_path=None):
+        super(ExtendedLabelBinarizer, self) \
+          .__init__(neg_label, pos_label, sparse_output)
         self.labelindex_path = labelindex_path
         if self.labelindex_path is not None:
             with open(self.labelindex_path, 'r') as f:
                 self.labelindex = json.load(f)
+
     def fit(self, y):
         if self.labelindex_path is not None:
             super(ExtendedLabelBinarizer, self).fit(self.labelindex)


### PR DESCRIPTION
I add two types as 'label' and 'number' in custom_dict_vectorizer.

# 'label'
This is based on sklearn.preprocessing.LabelBinarizer.
I add some implements as ExtendedLabelBinarizer.
- Add same interface as Vectorizer.
- You can fix data source on fit (In custom_dict_vectorizer, you can use different datas on fit and transform.)
## config example
```
  student_department:
   name: "student_department"
   type: "label"
   vectorizer:
    sparse_output: True
    labelindex_path: "department.json"
```

# 'number'
This type is 1dim number(int32, float32) to 1dim like path-through.
## config example
```
  score:
   name: "score"
   type: "number"
   vectorizer:
    dtype: "float32"
```